### PR TITLE
Compose dev fixes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,7 +49,7 @@ services:
     stop_signal: SIGKILL
     restart: unless-stopped
     volumes:
-      - wooportal-db:/var/lib/postgresql/data
+      - wooportal-db:/var/lib/mysql
       - ./db:/docker-entrypoint-initdb.d
     environment:
       - MYSQL_ROOT_PASSWORD=wooportal
@@ -63,7 +63,7 @@ services:
       - "8013:1080"
       - "8014:1025"
     stop_signal: SIGKILL
-       
+
 volumes:
   wooportal-db:
     driver: local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       context: ./server
     networks: [default]
     ports: [8011:80]
-    restart: always
+    restart: unless-stopped
     volumes:
       - ./server/.storage:/data/media
       - ./server/src/main/resources/credentials:/data/credentials
@@ -40,7 +40,7 @@ services:
       - WOOPORTAL_PORTAL_NAME=Wooportal
       - WOOPORTAL_PUSH_SECRET=file:/data/credentials/firebase-credentials.json
       - WOOPORTAL_STORAGE_LOCATION=/data/media
-      
+
   server-db:
     container_name: wooportal.db
     image: mysql:5


### PR DESCRIPTION
Two fixes:
* there was a postgres path defined for the db container volume
* "unless-stopped" is probably what we want as a restart policy in dev, "always" leads to e.g. starting the container on restarting the computer if you shutdown with the container active and similar